### PR TITLE
Add workflow to sync security advisories with issues

### DIFF
--- a/.github/workflows/auto-security-issue.yml
+++ b/.github/workflows/auto-security-issue.yml
@@ -25,7 +25,7 @@ jobs:
         id: get_bug_bot_token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.BOT_APP_ID }}
+          client-id: ${{ secrets.BOT_APP_ID }} # Diubah dari app-id ke client-id
           private-key: ${{ secrets.BOT_PRIVATE_KEY }}
 
       - name: Extract info & Create/Update Issue
@@ -37,7 +37,6 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         with:
-          # Panggil token hasil generate dari step di atas
           github-token: ${{ steps.get_bug_bot_token.outputs.token }}
           script: |
             const payload = context.payload;
@@ -50,13 +49,24 @@ jobs:
             const botType = author === 'renovate[bot]' ? 'Renovate' : 'Dependabot';
 
             // ==========================================
-            // STRATEGI TAMBAHAN 1: Multi-Pattern ID Extractors (GHSA, CVE, OSV)
+            // STRATEGI TAMBAHAN 1: Multi-Pattern ID Extractors (Super Lengkap)
             // ==========================================
+            
+            // 1. GHSA ID
             const ghsaMatch = prBody.match(/(GHSA-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4})/i) || prTitle.match(/(GHSA-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4})/i);
             let ghsa = ghsaMatch ? ghsaMatch[1].toUpperCase() : 'No GHSA';
             
+            // 2. CVE ID
             const cveMatch = prBody.match(/(CVE-\d{4}-\d{4,7})/i) || prTitle.match(/(CVE-\d{4}-\d{4,7})/i);
             let cve = cveMatch ? cveMatch[1].toUpperCase() : 'No CVE';
+
+            // 3. CWE ID (Common Weakness Enumeration)
+            const cweMatch = prBody.match(/(CWE-\d+)/i) || prTitle.match(/(CWE-\d+)/i);
+            let extractedCwe = cweMatch ? cweMatch[1].toUpperCase() : null;
+
+            // 4. Alternate OSV/Ecosystem ID (Snyk, NPM, RustSec, PySec, Go, dll)
+            const osvMatch = prBody.match(/(SNYK-[a-zA-Z0-9-]+|NPM-\d+-\d+|RUSTSEC-\d{4}-\d+|PYSEC-\d{4}-\d+|GO-\d{4}-\d+)/i);
+            let osvId = osvMatch ? osvMatch[1].toUpperCase() : 'No Alt ID';
 
             // Deteksi nama paket kerentanan (Diperkuat dengan pola ganda)
             let pkg = 'Unknown';
@@ -74,14 +84,14 @@ jobs:
             // Inisialisasi variabel penampung data
             let severity = 'UNKNOWN';
             let cvss = 'N/A';
-            let title = `Security Update: ${pkg} (${ghsa})`; // Fallback awal
+            let title = `Security Update: ${pkg} (${ghsa !== 'No GHSA' ? ghsa : (cve !== 'No CVE' ? cve : osvId)})`; // Fallback dinamis
             let summaryDesc = `${botType} security update detected.`;
-            let cweList = 'N/A';
+            let cweList = extractedCwe ? extractedCwe : 'N/A';
             let vulnRange = 'Unknown';
             let patched = 'None';
 
             // ==========================================
-            // STRATEGI TAMBAHAN 2: Fetch Ganda (Public Advisory API + GitHub REST/GraphQL Fallback)
+            // STRATEGI TAMBAHAN 2: Fetch Ganda (Public Advisory API)
             // ==========================================
             if (ghsa !== 'No GHSA') {
               try {
@@ -98,6 +108,7 @@ jobs:
                   if (advData.cve_id) cve = advData.cve_id;
 
                   if (advData.cwes && advData.cwes.length > 0) {
+                    // Timpa cweList manual dengan data resmi dari API jika ada
                     cweList = advData.cwes.map(c => `${c.cwe_id} (${c.name})`).join(', ');
                   }
 
@@ -129,7 +140,7 @@ jobs:
                 const prComments = await github.rest.issues.listComments({
                   owner, repo, issue_number: parseInt(process.env.PR_NUMBER)
                 });
-                // Mencari petunjuk tambahan dari komentar bot Dependabot jika ada
+                
                 for (const comment of prComments.data) {
                   const bodyText = comment.body;
                   const foundGhsa = bodyText.match(/(GHSA-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4})/i);
@@ -151,15 +162,15 @@ jobs:
 
             // Fallback Judul Darurat (Jika API gagal dan judul masih bawaan)
             if (title.startsWith('Security Update:')) {
-               if (severity !== 'UNKNOWN' && cve !== 'No CVE') {
-                 title = `Security: ${severity} - ${pkg} (${ghsa} / ${cve})`;
+               if (severity !== 'UNKNOWN' && (cve !== 'No CVE' || osvId !== 'No Alt ID')) {
+                 title = `Security: ${severity} - ${pkg} (${ghsa !== 'No GHSA' ? ghsa : (cve !== 'No CVE' ? cve : osvId)})`;
                } else {
-                 title = `Security Advisory: ${pkg} (${ghsa})`;
+                 title = `Security Advisory: ${pkg} (${ghsa !== 'No GHSA' ? ghsa : 'Unknown ID'})`;
                }
             }
 
-            // FILTER ANTI-SPAM
-            if (botType === 'Dependabot' && severity === 'UNKNOWN' && ghsa === 'No GHSA' && cve === 'No CVE') {
+            // FILTER ANTI-SPAM (Diperketat: skip cuma kalau semua ID kosong)
+            if (botType === 'Dependabot' && severity === 'UNKNOWN' && ghsa === 'No GHSA' && cve === 'No CVE' && osvId === 'No Alt ID') {
               console.log('✅ PR Dependabot ini adalah update versi normal. Melewati pembuatan Issue...');
               return; 
             }
@@ -187,7 +198,7 @@ jobs:
             );
             const existing = issues.find(i => i.title === title);
 
-            // 3. STRUKTUR FORMAT PADA BODY ISSUE (Rata Kiri)
+            // 3. STRUKTUR FORMAT PADA BODY ISSUE
             const body = `## 🛡️ Security Vulnerability (from ${botType} PR #${process.env.PR_NUMBER})
 
             ### Description
@@ -205,6 +216,7 @@ jobs:
             ### Identifiers
             - **GHSA ID:** ${ghsa}
             - **CVE ID:** ${cve}
+            - **Alt ID (OSV/Snyk):** ${osvId}
             
             ### Weaknesses
             - ${cweList}

--- a/.github/workflows/sync-security-advisory.yml
+++ b/.github/workflows/sync-security-advisory.yml
@@ -1,0 +1,145 @@
+name: Sync Security Advisories
+
+on:
+  schedule:
+    # Berjalan setiap hari Minggu jam 00:00 UTC (1 minggu sekali)
+    - cron: '0 0 * * 0'
+  workflow_dispatch: # Tombol manual buat testing
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  sync-advisories:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate Bot Token
+        id: bot_token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_PRIVATE_KEY }}
+
+      - name: Sync Old Issues with Latest Advisory Data
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.bot_token.outputs.token }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            console.log("🔍 Mengambil semua tiket Issue Keamanan...");
+            
+            // 1. Ambil semua issue dengan label 'Security' dan 'Auto Create Issues' (Open & Closed)
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: 'all', // Termasuk yang sudah closed as completed
+              labels: 'Security,Auto Create Issues',
+              per_page: 100
+            });
+
+            console.log(`Ditemukan ${issues.length} tiket untuk disinkronisasi.`);
+
+            for (const issue of issues) {
+              const oldBody = issue.body || '';
+              
+              // 2. Cari GHSA ID dari teks body Issue lama
+              const ghsaMatch = oldBody.match(/\*\*GHSA ID:\*\*\s*(GHSA-[A-Z0-9-]+)/i);
+              if (!ghsaMatch) continue; // Skip jika tidak ada GHSA
+              
+              const ghsa = ghsaMatch[1].toUpperCase();
+              console.log(`\n⏳ Menyelaraskan Issue #${issue.number} (${ghsa})...`);
+
+              try {
+                // 3. Fetch data TERBARU dari GitHub Advisory API
+                const advResponse = await fetch(`https://api.github.com/advisories/${ghsa}`);
+                if (!advResponse.ok) {
+                  console.log(`⚠️ API mengembalikan status ${advResponse.status}, melewati...`);
+                  continue;
+                }
+                const advData = await advResponse.json();
+
+                // 4. Ekstrak data metadata lama agar tidak hilang (Package, PR, dll)
+                const prMatch = oldBody.match(/from (Renovate|Dependabot) PR #(\d+)/i) || [];
+                const botType = prMatch[1] || 'Dependabot';
+                const prNumber = prMatch[2] || 'Unknown';
+                
+                const urlMatch = oldBody.match(/- PR: (https:\/\/github.com\/[^\s]+)/i) || [];
+                const prUrl = urlMatch[1] || `https://github.com/${owner}/${repo}/pull/${prNumber}`;
+                
+                const pkgMatch = oldBody.match(/\*\*Package:\*\*\s*([^\n]+)/i) || [];
+                const pkg = pkgMatch[1] || 'Unknown';
+                
+                const osvMatch = oldBody.match(/\*\*Alt ID \(OSV\/Snyk\):\*\*\s*([^\n]+)/i) || [];
+                const osvId = osvMatch[1] || 'No Alt ID';
+                
+                const vulnRangeMatch = oldBody.match(/\*\*Affected versions:\*\*\n\s+- ([^\n]+)/i) || [];
+                const vulnRange = vulnRangeMatch[1] || 'Unknown';
+                
+                const patchedMatch = oldBody.match(/\*\*Patched versions:\*\*\s*([^\n]+)/i) || [];
+                const patched = patchedMatch[1] || 'None';
+
+                // 5. Timpa dengan data Advisory TERBARU
+                const title = advData.summary || issue.title;
+                const summaryDesc = advData.description || 'No description available.';
+                const severity = advData.severity ? advData.severity.toUpperCase() : 'UNKNOWN';
+                const cvss = advData.cvss && advData.cvss.score ? advData.cvss.score.toString() : 'N/A';
+                const cve = advData.cve_id ? advData.cve_id : 'No CVE';
+                const cweList = advData.cwes && advData.cwes.length > 0 ? advData.cwes.map(c => `${c.cwe_id} (${c.name})`).join(', ') : 'N/A';
+
+                // 6. Rangkai Ulang Body (Format Sama Persis)
+                const newBody = `## 🛡️ Security Vulnerability (from ${botType} PR #${prNumber})
+
+            ### Description
+            ${summaryDesc}
+            
+            ### Severity Check
+            - ${severity === 'LOW' ? '☑' : '☐'} Low
+            - ${severity === 'MODERATE' ? '☑' : '☐'} Moderate
+            - ${severity === 'HIGH' ? '☑' : '☐'} High
+            - ${severity === 'CRITICAL' ? '☑' : '☐'} Critical
+            
+            ### Severity Score
+            ${cvss} / 10
+            
+            ### Identifiers
+            - **GHSA ID:** ${ghsa}
+            - **CVE ID:** ${cve}
+            - **Alt ID (OSV/Snyk):** ${osvId}
+            
+            ### Weaknesses
+            - ${cweList}
+            
+            ### Affected
+            - **Package:** ${pkg}
+            - **Affected versions:**
+              - ${vulnRange}
+            - **Patched versions:** ${patched}
+            
+            ### References
+            - Advisory: https://github.com/advisories/${ghsa}
+            - PR: ${prUrl}
+            
+            ---
+            _Auto-generated from ${botType} security PR. Fix by merging PR #${prNumber}._`;
+
+                // 7. Bandingkan dan Update jika ada perubahan (Hindari spam update)
+                if (newBody !== oldBody) {
+                  await github.rest.issues.update({
+                    owner,
+                    repo,
+                    issue_number: issue.number,
+                    title: title, // Update judul jika advisory punya nama yg lebih spesifik
+                    body: newBody
+                  });
+                  console.log(`✅ Berhasil! Issue #${issue.number} telah diperbarui dengan data Advisory terkini.`);
+                } else {
+                  console.log(`➖ Issue #${issue.number} sudah sinkron, tidak ada pembaruan.`);
+                }
+
+              } catch (e) {
+                console.log(`❌ Gagal menyelaraskan Issue #${issue.number}: ${e.message}`);
+              }
+            }


### PR DESCRIPTION
This workflow synchronizes security advisories with existing GitHub issues labeled 'Security' and 'Auto Create Issues'. It runs weekly and can also be triggered manually.